### PR TITLE
Add ZipCode Service and Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeController.java
@@ -1,9 +1,41 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import org.springframework.web.bind.annotation.RestController;
+import edu.ucsb.cs156.spring.backenddemo.services.ZipCodeQueryService;
 
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Zip Code Information from http://www.zippopotam.us/")
+@Slf4j
+@RequestMapping("/api/zipcode")
 @RestController
 public class ZipCodeController {
-    
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    ZipCodeQueryService zipcodeQueryService;
+
+    @Operation(summary = "Get information about a us zipcode")
+    @GetMapping("/get")
+    public ResponseEntity<String> getZipcode(
+            @Parameter(name = "zipcode", description = "US zipcode", example = "93106") @RequestParam String zipcode)
+            throws JsonProcessingException {
+        log.info("getZipcode: zipcode={}", zipcode);
+
+        String result = zipcodeQueryService.getJSON(zipcode);
+        return ResponseEntity.ok().body(result);
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
@@ -36,10 +36,11 @@ public class ZipCodeQueryService {
     public String getJSON(String zipcode) throws HttpClientErrorException {
         log.info("zipcode={}", zipcode);
         HttpHeaders headers = new HttpHeaders();
-        Map<String, String> uriVariables = Map.of("zipcode", zipcode);
 
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, String> uriVariables = Map.of("zipcode", zipcode);
 
         HttpEntity<String> entity = new HttpEntity<>(headers);
 

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
@@ -2,13 +2,28 @@ package edu.ucsb.cs156.spring.backenddemo.services;
 
 import org.springframework.web.client.RestTemplate;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.util.List;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
+
+@Slf4j
 @Service
 public class ZipCodeQueryService {
+
+    ObjectMapper mapper = new ObjectMapper();
 
     private final RestTemplate restTemplate;
 
@@ -19,6 +34,20 @@ public class ZipCodeQueryService {
     public static final String ENDPOINT = "http://api.zippopotam.us/us/{zipcode}";
 
     public String getJSON(String zipcode) throws HttpClientErrorException {
-        return "";
+        log.info("zipcode={}", zipcode);
+        HttpHeaders headers = new HttpHeaders();
+        Map<String, String> uriVariables = Map.of("zipcode", zipcode);
+
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        String ucsbZip = "93106"; // hard coded params for UCSB zip code
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+        return re.getBody();
+
     }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
@@ -16,9 +16,9 @@ public class ZipCodeQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "http://api.zippopotam.us/us/{zipcode}";
 
     public String getJSON(String zipcode) throws HttpClientErrorException {
-       return "";
+        return "";
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeControllerTests.java
@@ -1,0 +1,57 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.ZipCodeQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+
+@WebMvcTest(value = ZipCodeController.class)
+public class ZipCodeControllerTests {
+  private ObjectMapper mapper = new ObjectMapper();
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  ZipCodeQueryService mockZipCodeQueryService;
+
+  @Test
+  public void test_getZipCode() throws Exception {
+
+    String fakeJsonResult = "{ \"fake\" : \"result\" }";
+    String zipcode = "93106";
+    when(mockZipCodeQueryService.getJSON(eq(zipcode))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/zipcode/get?zipcode=%s", zipcode);
+
+    MvcResult response = mockMvc
+        .perform(get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryServiceTests.java
@@ -1,0 +1,40 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(ZipCodeQueryService.class)
+public class ZipCodeQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private ZipCodeQueryService zipcodeQueryService;
+
+    @Test
+    public void test_getJSON() {
+
+        String zipcode = "92103";
+        String expectedURL = ZipCodeQueryService.ENDPOINT.replace("{zipcode}", zipcode);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = zipcodeQueryService.getJSON(zipcode);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/zipcode/get` that can be used to get information
about the location of a particular zipcode.
http://team01-walexgreen-dev.dokku-13.cs.ucsb.edu/swagger-ui/index.html#/Zip%20Code%20Information%20from%20http%3A

Closes #17 